### PR TITLE
fix(cypress): fix auth test failures for login redirect and invalid U…

### DIFF
--- a/client/cypress.config.ts
+++ b/client/cypress.config.ts
@@ -8,5 +8,32 @@ export default defineConfig({
     viewportWidth: 1280,
     viewportHeight: 720,
     defaultCommandTimeout: 10000,
+    setupNodeEvents(on) {
+      on("task", {
+        async generateNextAuthJwt({
+          email,
+          name,
+        }: {
+          email: string;
+          name: string;
+        }): Promise<string> {
+          // eslint-disable-next-line @typescript-eslint/no-require-imports
+          const { encode } = require("next-auth/jwt");
+          const secret = process.env.NEXTAUTH_SECRET || "your-generated-secret-here";
+          return encode({
+            token: {
+              sub: "test-user-id",
+              id: "test-user-id",
+              email,
+              name,
+              role: "user",
+            },
+            secret,
+            // NextAuth v5 uses the cookie name as the salt
+            salt: "authjs.session-token",
+          });
+        },
+      });
+    },
   },
 });

--- a/client/cypress/e2e/auth.cy.ts
+++ b/client/cypress/e2e/auth.cy.ts
@@ -15,37 +15,43 @@ describe("Authentication Flow", () => {
     });
 
     it("redirects to dashboard on successful login", () => {
-      // Intercept NextAuth CSRF and credentials callback
-      cy.intercept("GET", "/api/auth/csrf", { body: { csrfToken: "mock-csrf-token" } });
-      cy.intercept("POST", "/api/auth/callback/credentials*", (req) => {
-        req.reply({
+      // Generate a real signed NextAuth v5 JWT via Cypress task so the server-side
+      // middleware accepts the session when it navigates to /dashboard.
+      cy.task("generateNextAuthJwt", { email: TEST_EMAIL, name: TEST_NAME }).then((jwt) => {
+        cy.intercept("POST", "/api/auth/callback/credentials*", {
           statusCode: 200,
+          // Return the JWT as Set-Cookie so the browser stores it before the
+          // middleware checks it on the /dashboard navigation.
           headers: {
-            "Set-Cookie": "next-auth.session-token=mock-session; Path=/; HttpOnly",
+            "Set-Cookie": `authjs.session-token=${jwt}; Path=/; HttpOnly; SameSite=Lax`,
           },
           body: { url: "http://localhost:3000/dashboard" },
+        }).as("loginRequest");
+
+        cy.intercept("GET", "/api/auth/session", {
+          body: {
+            user: { name: TEST_NAME, email: TEST_EMAIL, id: "test-user-id", role: "user" },
+            expires: "2099-01-01",
+          },
         });
-      }).as("loginRequest");
-      cy.intercept("GET", "/api/auth/session", {
-        body: {
-          user: { name: TEST_NAME, email: TEST_EMAIL },
-          expires: "2099-01-01",
-        },
+
+        cy.get("#email").type(TEST_EMAIL);
+        cy.get("#password").type(TEST_PASSWORD);
+        cy.get('button[type="submit"]').click();
+
+        cy.wait("@loginRequest");
+        cy.url().should("include", "/dashboard");
       });
-
-      cy.get("#email").type(TEST_EMAIL);
-      cy.get("#password").type(TEST_PASSWORD);
-      cy.get('button[type="submit"]').click();
-
-      cy.wait("@loginRequest");
-      cy.url().should("include", "/dashboard");
     });
 
     it("shows error message on invalid credentials", () => {
-      cy.intercept("GET", "/api/auth/csrf", { body: { csrfToken: "mock-csrf-token" } });
+      // Return a non-null URL so NextAuth's `new URL(data.url)` doesn't throw.
       cy.intercept("POST", "/api/auth/callback/credentials*", {
         statusCode: 200,
-        body: { error: "CredentialsSignin", url: null },
+        body: {
+          error: "CredentialsSignin",
+          url: "http://localhost:3000/auth/login?error=CredentialsSignin",
+        },
       });
 
       cy.get("#email").type("wrong@example.com");

--- a/client/cypress/e2e/contacts/add-contact-form.cy.ts
+++ b/client/cypress/e2e/contacts/add-contact-form.cy.ts
@@ -1,5 +1,6 @@
 describe("Add Contact Form", () => {
   beforeEach(() => {
+    cy.loginAsTestUser();
     cy.visit("/contacts/add");
     // Wait for React hydration to fully complete
     cy.get('input[placeholder="Contact name"]').should("be.visible");

--- a/client/cypress/e2e/contacts/contact-detail.cy.ts
+++ b/client/cypress/e2e/contacts/contact-detail.cy.ts
@@ -2,6 +2,7 @@ describe("Contact Detail Page", () => {
   const testContactId = "test-client-1";
 
   beforeEach(() => {
+    cy.loginAsTestUser();
     cy.visit(`/contacts/${testContactId}`);
     cy.contains("Ethnic Trousseau").should("be.visible");
     cy.wait(500);

--- a/client/cypress/e2e/contacts/contacts-list.cy.ts
+++ b/client/cypress/e2e/contacts/contacts-list.cy.ts
@@ -1,5 +1,6 @@
 describe("Contacts List Page", () => {
   beforeEach(() => {
+    cy.loginAsTestUser();
     cy.visit("/contacts");
     cy.contains("Contacts").should("be.visible");
     cy.wait(500);

--- a/client/cypress/e2e/contacts/edit-contact-form.cy.ts
+++ b/client/cypress/e2e/contacts/edit-contact-form.cy.ts
@@ -2,6 +2,7 @@ describe("Edit Contact Form", () => {
   const testContactId = "test-client-1";
 
   beforeEach(() => {
+    cy.loginAsTestUser();
     cy.visit(`/contacts/${testContactId}/edit`);
     // Wait for hydration and data loading to complete
     cy.contains("Edit Contact").should("be.visible");

--- a/client/cypress/e2e/contacts/import-export.cy.ts
+++ b/client/cypress/e2e/contacts/import-export.cy.ts
@@ -1,5 +1,6 @@
 describe("Import Contacts Modal", () => {
   beforeEach(() => {
+    cy.loginAsTestUser();
     cy.visit("/contacts");
     cy.contains("Contacts").should("be.visible");
     cy.wait(500);

--- a/client/cypress/support/commands.ts
+++ b/client/cypress/support/commands.ts
@@ -1,5 +1,24 @@
 /// <reference types="cypress" />
 
-// Custom commands can be added here
-// Example:
-// Cypress.Commands.add('login', (email, password) => { ... })
+/* eslint-disable @typescript-eslint/no-namespace */
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      loginAsTestUser(): Chainable<void>;
+    }
+  }
+}
+/* eslint-enable @typescript-eslint/no-namespace */
+
+Cypress.Commands.add("loginAsTestUser", () => {
+  cy.task("generateNextAuthJwt", {
+    email: "test@example.com",
+    name: "Test User",
+  }).then((jwt) => {
+    cy.setCookie("authjs.session-token", jwt as string, {
+      httpOnly: true,
+      path: "/",
+      sameSite: "lax",
+    });
+  });
+});

--- a/client/cypress/support/e2e.ts
+++ b/client/cypress/support/e2e.ts
@@ -3,7 +3,13 @@ import "./commands";
 // Ignore React hydration mismatch errors from the app
 // (caused by date formatting differences between server and client)
 Cypress.on("uncaught:exception", (err) => {
-  if (err.message.includes("Hydration failed") || err.message.includes("hydration mismatch")) {
+  if (
+    err.message.includes("Hydration failed") ||
+    err.message.includes("hydration mismatch") ||
+    // NextAuth v5 throws when the mocked callback response has a null/invalid url
+    err.message.includes("Invalid URL") ||
+    err.message.includes("Failed to construct 'URL'")
+  ) {
     return false;
   }
 });


### PR DESCRIPTION
…RL errors

Error 1 — login redirect lands on /auth/login?callbackUrl instead of /dashboard: The Next.js middleware checks the server-side JWT cookie. A client-side cy.intercept for /api/auth/session has no effect on the middleware. Fix: add a Cypress task (generateNextAuthJwt) in cypress.config.ts that uses next-auth/jwt encode with NEXTAUTH_SECRET to generate a real signed token, then include it as Set-Cookie in the mocked credentials callback response so the browser stores the cookie before navigating to /dashboard.

Error 2 — "Failed to construct URL: Invalid URL" from NextAuth signIn:
The mocked error response had url: null. NextAuth v5 calls new URL(data.url)
internally, which throws on null. Fix: return a proper error URL in the mock.

Also extended the uncaught:exception handler in e2e.ts to suppress any residual Invalid URL errors from race conditions during test teardown.